### PR TITLE
Mysql + Rails 3.0.10 - was not working. Now it does.

### DIFF
--- a/lib/foreign_keys.rb
+++ b/lib/foreign_keys.rb
@@ -1,3 +1,8 @@
+require 'active_record'
+require 'active_record/connection_adapters/abstract_adapter'
+require 'active_record/connection_adapters/mysql_adapter'
+require 'active_record/connection_adapters/postgresql_adapter'
+
 require "foreign_keys/connection_adapters/abstract"
 require "foreign_keys/connection_adapters/mysql"
 require "foreign_keys/connection_adapters/postgresql"


### PR DESCRIPTION
Fixing an issue in rails 3.0.10 where the connection adapters were not loaded yet and so the schema dumper was failing on mysql.
