### PR TITLE
Conditionalize inclusion of Mysql and PG resources, and port to Rails 3.2

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,4 +1,5 @@
---- 
-:minor: 0
-:patch: 0
+---
 :major: 2
+:minor: 0
+:patch: 1
+:build: 

--- a/foreign_keys.gemspec
+++ b/foreign_keys.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{foreign_keys}
-  s.version = "2.0.0.r3pg"
+  s.version = "2.0.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Tanel Suurhans", "Tarmo Lehtpuu"]

--- a/foreign_keys.gemspec
+++ b/foreign_keys.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{foreign_keys}
-  s.version = "2.0.0"
+  s.version = "2.0.0.r3pg"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Tanel Suurhans", "Tarmo Lehtpuu"]

--- a/lib/foreign_keys.rb
+++ b/lib/foreign_keys.rb
@@ -1,11 +1,11 @@
 require 'active_record'
 require 'active_record/connection_adapters/abstract_adapter'
-# require 'active_record/connection_adapters/mysql_adapter'
-require 'active_record/connection_adapters/postgresql_adapter'
+require 'active_record/connection_adapters/mysql_adapter' if defined? Mysql
+require 'active_record/connection_adapters/postgresql_adapter' if defined? PG
 
 require "foreign_keys/connection_adapters/abstract"
-# require "foreign_keys/connection_adapters/mysql"
-require "foreign_keys/connection_adapters/postgresql"
+require "foreign_keys/connection_adapters/mysql" if defined? Mysql
+require "foreign_keys/connection_adapters/postgresql" if defined? PG
 
 require "foreign_keys/schema_dumper"
 

--- a/lib/foreign_keys.rb
+++ b/lib/foreign_keys.rb
@@ -1,6 +1,6 @@
 require 'active_record'
-# require 'active_record/connection_adapters/abstract_adapter'
-require 'active_record/connection_adapters/mysql_adapter'
+require 'active_record/connection_adapters/abstract_adapter'
+# require 'active_record/connection_adapters/mysql_adapter'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 require "foreign_keys/connection_adapters/abstract"

--- a/lib/foreign_keys.rb
+++ b/lib/foreign_keys.rb
@@ -1,10 +1,10 @@
 require 'active_record'
-require 'active_record/connection_adapters/abstract_adapter'
+# require 'active_record/connection_adapters/abstract_adapter'
 require 'active_record/connection_adapters/mysql_adapter'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 require "foreign_keys/connection_adapters/abstract"
-require "foreign_keys/connection_adapters/mysql"
+# require "foreign_keys/connection_adapters/mysql"
 require "foreign_keys/connection_adapters/postgresql"
 
 require "foreign_keys/schema_dumper"

--- a/lib/foreign_keys/connection_adapters/mysql.rb
+++ b/lib/foreign_keys/connection_adapters/mysql.rb
@@ -19,11 +19,11 @@ module Perfectline
         def foreign_keys(table_name)
           sql = execute("SHOW CREATE TABLE #{quote_table_name(table_name)}").fetch_hash["Create Table"]
 
-          returning([]) do |fks|
+          [].tap do |fks|
             sql.scan(/CONSTRAINT `(\w+)` FOREIGN KEY \((.*?)\) REFERENCES `(\w+)` \((.*?)\)(?:\s+ON DELETE\s+(.*?))?(?:\s+ON UPDATE\s+(.*?))?[,\)\n]/) do |name, cols, refs, keys, delete, update|
 
-              cols = returning([]){ |array| cols.scan(/`(\w+)`/) { |match| array << match.first.to_sym }}
-              keys = returning([]){ |array| keys.scan(/`(\w+)`/) { |match| array << match.first.to_sym }}
+              cols = [].tap { |array| cols.scan(/`(\w+)`/) { |match| array << match.first.to_sym }}
+              keys = [].tap { |array| keys.scan(/`(\w+)`/) { |match| array << match.first.to_sym }}
 
               fks.push({
                       :name       => name,

--- a/lib/foreign_keys/connection_adapters/postgresql.rb
+++ b/lib/foreign_keys/connection_adapters/postgresql.rb
@@ -37,7 +37,7 @@ module Perfectline
             t.table_name = '#{table_name}'
           }
 
-          foreign_keys = returning({}) do |foreign_keys|
+          foreign_keys = {}.tap do |foreign_keys|
             select_all(sql).each do |row|
               if foreign_keys.has_key?(row["name"])
                 foreign_keys[row["name"]][:columns] << row["from_column"]


### PR DESCRIPTION
I made the inclusion of Mysql and PG activerecord connectors conditional on the use their respective gems, so that projects like mine that use Postgres but not mysql won't need to include the mysql gem.

I also changed the "returning" method to the "tap" method, since the former is no longer available in Rails 3.2.
